### PR TITLE
Add a Partially Watched group to the Watched Recordings screen

### DIFF
--- a/mythtv/programs/mythfrontend/playbackbox.cpp
+++ b/mythtv/programs/mythfrontend/playbackbox.cpp
@@ -1776,7 +1776,8 @@ bool PlaybackBox::UpdateUILists(void)
                 continue;
             }
 
-            if (!p->IsWatched() &&
+            if ((m_viewMask & VIEW_PARTWATCH) &&
+                !p->IsWatched() &&
                 p->IsBookmarkSet() &&
                 !isLiveTVProg &&
                 pRecgroup != "Deleted")
@@ -5233,6 +5234,15 @@ bool ChangeView::Create()
                     m_parentScreen, SLOT(toggleWatchListView(bool)));
         }
     //
+
+    checkBox = dynamic_cast<MythUICheckBox*>(GetChild("partwatch"));
+    if (checkBox)
+    {
+        if (m_viewMask & PlaybackBox::VIEW_PARTWATCH)
+            checkBox->SetCheckState(MythUIStateType::Full);
+        connect(checkBox, SIGNAL(toggled(bool)),
+                m_parentScreen, SLOT(togglePartWatchView(bool)));
+    }
 
     checkBox = dynamic_cast<MythUICheckBox*>(GetChild("searches"));
     if (checkBox)

--- a/mythtv/programs/mythfrontend/playbackbox.cpp
+++ b/mythtv/programs/mythfrontend/playbackbox.cpp
@@ -100,6 +100,21 @@ static int comp_originalAirDate_rev(const ProgramInfo *a, const ProgramInfo *b)
         return (dt1 > dt2 ? 1 : -1);
 }
 
+static int comp_bookmarkUpdate(const ProgramInfo *a, const ProgramInfo *b)
+{
+    QDateTime dt1 = a->QueryBookmarkTimeStamp();
+    QDateTime dt2 = b->QueryBookmarkTimeStamp();
+
+    if (dt1.isValid() && dt2.isValid())
+        return (dt1 < dt2 ? 1 : -1);
+    else if (dt1.isValid() && !dt2.isValid())
+        return -1;
+    else if (!dt1.isValid() && dt2.isValid())
+        return 1;
+    else
+        return -1;
+}
+
 static int comp_recpriority2(const ProgramInfo *a, const ProgramInfo *b)
 {
     if (a->GetRecordingPriority2() == b->GetRecordingPriority2())
@@ -176,6 +191,12 @@ static bool comp_originalAirDate_rev_less_than(
     const ProgramInfo *a, const ProgramInfo *b)
 {
     return comp_originalAirDate_rev(a, b) < 0;
+}
+
+static bool comp_bookmarkUpdate_less_than(
+    const ProgramInfo *a, const ProgramInfo *b)
+{
+    return comp_bookmarkUpdate(a, b) < 0;
 }
 
 static bool comp_recpriority2_less_than(
@@ -415,6 +436,8 @@ PlaybackBox::PlaybackBox(MythScreenStack *parent, QString name,
       m_recGroup("All Programs"),
       m_watchGroupName(tr("Watch List")),
       m_watchGroupLabel(m_watchGroupName.toLower()),
+      m_partialGroupName(tr("Partially Watched")),
+      m_partialGroupLabel(m_partialGroupName.toLower()),
       m_viewMask(VIEW_TITLES),
 
       // General m_popupMenu support
@@ -1753,6 +1776,15 @@ bool PlaybackBox::UpdateUILists(void)
                 continue;
             }
 
+            if (!p->IsWatched() &&
+                p->IsBookmarkSet() &&
+                !isLiveTVProg &&
+                pRecgroup != "Deleted")
+            {
+                m_progLists[m_partialGroupLabel].push_front(p);
+                m_progLists[m_partialGroupLabel].setAutoDelete(false);
+            }
+
             // Show titles
             if ((m_viewMask & VIEW_TITLES) && (!isLiveTVProg || isLiveTvGroup))
             {
@@ -1902,6 +1934,13 @@ bool PlaybackBox::UpdateUILists(void)
                                  comp_season_less_than);
             }
         }
+    }
+
+    if (!m_progLists[m_partialGroupLabel].empty())
+    {
+        std::stable_sort(m_progLists[m_partialGroupLabel].begin(),
+                         m_progLists[m_partialGroupLabel].end(),
+                         comp_bookmarkUpdate_less_than);
     }
 
     if (!m_progLists[m_watchGroupLabel].empty())
@@ -2145,6 +2184,8 @@ bool PlaybackBox::UpdateUILists(void)
     }
 
     m_titleList = QStringList("");
+    if (m_progLists[m_partialGroupLabel].size() > 0)
+        m_titleList << m_partialGroupName;
     if (m_progLists[m_watchGroupLabel].size() > 0)
         m_titleList << m_watchGroupName;
     if ((m_progLists["livetv"].size() > 0) &&

--- a/mythtv/programs/mythfrontend/playbackbox.h
+++ b/mythtv/programs/mythfrontend/playbackbox.h
@@ -382,6 +382,8 @@ class PlaybackBox : public ScheduleCommon
     QString             m_newRecGroup;
     QString             m_watchGroupName;
     QString             m_watchGroupLabel;
+    QString             m_partialGroupName;
+    QString             m_partialGroupLabel;
     ViewMask            m_viewMask;
 
     // Popup support //////////////////////////////////////////////////////////

--- a/mythtv/programs/mythfrontend/playbackbox.h
+++ b/mythtv/programs/mythfrontend/playbackbox.h
@@ -90,6 +90,7 @@ class PlaybackBox : public ScheduleCommon
         VIEW_WATCHLIST  =  0x0008,
         VIEW_SEARCHES   =  0x0010,
         VIEW_LIVETVGRP  =  0x0020,
+        VIEW_PARTWATCH  =  0x0040,
         // insert new entries above here
         VIEW_WATCHED    =  0x8000
     } ViewMask;
@@ -200,6 +201,7 @@ class PlaybackBox : public ScheduleCommon
     void toggleCategoryView(bool setOn)  { toggleView(VIEW_CATEGORIES, setOn); }
     void toggleRecGroupView(bool setOn)  { toggleView(VIEW_RECGROUPS, setOn); }
     void toggleWatchListView(bool setOn) { toggleView(VIEW_WATCHLIST, setOn); }
+    void togglePartWatchView(bool setOn) { toggleView(VIEW_PARTWATCH, setOn); }
     void toggleSearchView(bool setOn)    { toggleView(VIEW_SEARCHES, setOn); }
     void toggleLiveTVView(bool setOn)    { toggleView(VIEW_LIVETVGRP, setOn); }
     void toggleWatchedView(bool setOn)   { toggleView(VIEW_WATCHED, setOn); }

--- a/mythtv/themes/MythCenter-wide/recordings-ui.xml
+++ b/mythtv/themes/MythCenter-wide/recordings-ui.xml
@@ -468,7 +468,7 @@
     </window>
 
     <window name="changeview">
-        <area>-1,-1,500,500</area>
+        <area>-1,-1,500,550</area>
         <shape name="backimg" from="basepopupbackground">
             <area>0,0,100%,100%</area>
         </shape>
@@ -507,44 +507,53 @@
             <value>Show Recording Groups</value>
         </textarea>
 
-        <checkbox name="watchlist" from="basecheckbox">
+        <checkbox name="partwatch" from="basecheckbox">
             <position>90,240</position>
         </checkbox>
 
-        <textarea name="watchlabel" from="titlelabel">
+        <textarea name="partlabel" from="titlelabel">
             <position>140,240</position>
+            <value>Show Partially Watched</value>
+        </textarea>
+
+        <checkbox name="watchlist" from="basecheckbox">
+            <position>90,290</position>
+        </checkbox>
+
+        <textarea name="watchlabel" from="titlelabel">
+            <position>140,290</position>
             <value>Show Watch List</value>
         </textarea>
 
         <checkbox name="searches" from="basecheckbox">
-            <position>90,290</position>
+            <position>90,340</position>
         </checkbox>
 
         <textarea name="searchlabel" from="titlelabel">
-            <position>140,290</position>
+            <position>140,340</position>
             <value>Show Searches</value>
         </textarea>
 
         <checkbox name="livetv" from="basecheckbox">
-            <position>90,340</position>
+            <position>90,390</position>
         </checkbox>
 
         <textarea name="livelabel" from="titlelabel">
-            <position>140,340</position>
+            <position>140,390</position>
             <value>Show LiveTV</value>
         </textarea>
 
         <checkbox name="watched" from="basecheckbox">
-            <position>90,390</position>
+            <position>90,440</position>
         </checkbox>
 
         <textarea name="watchedlabel" from="titlelabel">
-            <position>140,390</position>
+            <position>140,440</position>
             <value>Show Watched Programs</value>
         </textarea>
 
         <button name="save" from="basebutton">
-            <position>314,434</position>
+            <position>314,484</position>
             <value>Save</value>
         </button>
     </window>

--- a/mythtv/themes/MythCenter/recordings-ui.xml
+++ b/mythtv/themes/MythCenter/recordings-ui.xml
@@ -468,7 +468,7 @@
     </window>
 
     <window name="changeview">
-        <area>-1,-1,500,500</area>
+        <area>-1,-1,500,550</area>
         <shape name="backimg" from="basepopupbackground">
             <area>0,0,100%,100%</area>
         </shape>
@@ -507,44 +507,53 @@
             <value>Show Recording Groups</value>
         </textarea>
 
-        <checkbox name="watchlist" from="basecheckbox">
+        <checkbox name="partwatch" from="basecheckbox">
             <position>90,240</position>
         </checkbox>
 
-        <textarea name="watchlabel" from="titlelabel">
+        <textarea name="partlabel" from="titlelabel">
             <position>140,240</position>
+            <value>Show Partially Watched</value>
+        </textarea>
+
+        <checkbox name="watchlist" from="basecheckbox">
+            <position>90,290</position>
+        </checkbox>
+
+        <textarea name="watchlabel" from="titlelabel">
+            <position>140,290</position>
             <value>Show Watch List</value>
         </textarea>
 
         <checkbox name="searches" from="basecheckbox">
-            <position>90,290</position>
+            <position>90,340</position>
         </checkbox>
 
         <textarea name="searchlabel" from="titlelabel">
-            <position>140,290</position>
+            <position>140,340</position>
             <value>Show Searches</value>
         </textarea>
 
         <checkbox name="livetv" from="basecheckbox">
-            <position>90,340</position>
+            <position>90,390</position>
         </checkbox>
 
         <textarea name="livelabel" from="titlelabel">
-            <position>140,340</position>
+            <position>140,390</position>
             <value>Show LiveTV</value>
         </textarea>
 
         <checkbox name="watched" from="basecheckbox">
-            <position>90,390</position>
+            <position>90,440</position>
         </checkbox>
 
         <textarea name="watchedlabel" from="titlelabel">
-            <position>140,390</position>
+            <position>140,440</position>
             <value>Show Watched Programs</value>
         </textarea>
 
         <button name="save" from="basebutton">
-            <position>314,434</position>
+            <position>314,484</position>
             <value>Save</value>
         </button>
     </window>

--- a/mythtv/themes/Terra/recordings-ui.xml
+++ b/mythtv/themes/Terra/recordings-ui.xml
@@ -363,7 +363,7 @@
     </window>
 
     <window name="changeview">
-        <area>0,42,1280,515</area>
+        <area>0,42,1280,555</area>
         <shape name="fade" from="basefadebackground" />
 
         <imagetype name="backimg">
@@ -405,44 +405,53 @@
             <value>Show Recording Groups</value>
         </textarea>
 
-        <checkbox name="watchlist" from="basecheckbox">
+        <checkbox name="partwatch" from="basecheckbox">
             <position>940,348</position>
         </checkbox>
 
-        <textarea name="watchlabel" from="titlelabel">
+        <textarea name="partlabel" from="titlelabel">
             <position>990,353</position>
+            <value>Show Partially Watched</value>
+        </textarea>
+
+        <checkbox name="watchlist" from="basecheckbox">
+            <position>940,388</position>
+        </checkbox>
+
+        <textarea name="watchlabel" from="titlelabel">
+            <position>990,393</position>
             <value>Show Watch List</value>
         </textarea>
 
         <checkbox name="searches" from="basecheckbox">
-            <position>940,388</position>
+            <position>940,428</position>
         </checkbox>
 
         <textarea name="searchlabel" from="titlelabel">
-            <position>990,393</position>
+            <position>990,433</position>
             <value>Show Searches</value>
         </textarea>
 
         <checkbox name="livetv" from="basecheckbox">
-            <position>940,428</position>
+            <position>940,468</position>
         </checkbox>
 
         <textarea name="livelabel" from="titlelabel">
-            <position>990,433</position>
+            <position>990,473</position>
             <value>Show LiveTV</value>
         </textarea>
 
         <checkbox name="watched" from="basecheckbox">
-            <position>940,468</position>
+            <position>940,508</position>
         </checkbox>
 
         <textarea name="watchedlabel" from="titlelabel">
-            <position>990,473</position>
+            <position>990,513</position>
             <value>Show Watched Recordings</value>
         </textarea>
 
         <button name="save" from="basebutton">
-            <position>968,515</position>
+            <position>968,555</position>
             <value>Save</value>
         </button>
     </window>

--- a/mythtv/themes/default/recordings-ui.xml
+++ b/mythtv/themes/default/recordings-ui.xml
@@ -280,7 +280,7 @@
     </window>
 
     <window name="changeview">
-        <area>-1,-1,500,500</area>
+        <area>-1,-1,500,550</area>
         <imagetype name="backimg">
             <filename>mythdialogbox-background.png</filename>
         </imagetype>
@@ -319,44 +319,53 @@
             <value>Show Recording Groups</value>
         </textarea>
 
-        <checkbox name="watchlist" from="basecheckbox">
+        <checkbox name="partwatch" from="basecheckbox">
             <position>90,240</position>
         </checkbox>
 
-        <textarea name="watchlabel" from="titlelabel">
+        <textarea name="partlabel" from="titlelabel">
             <position>140,240</position>
+            <value>Show Partially Watched</value>
+        </textarea>
+
+        <checkbox name="watchlist" from="basecheckbox">
+            <position>90,290</position>
+        </checkbox>
+
+        <textarea name="watchlabel" from="titlelabel">
+            <position>140,290</position>
             <value>Show Watch List</value>
         </textarea>
 
         <checkbox name="searches" from="basecheckbox">
-            <position>90,290</position>
+            <position>90,340</position>
         </checkbox>
 
         <textarea name="searchlabel" from="titlelabel">
-            <position>140,290</position>
+            <position>140,340</position>
             <value>Show Searches</value>
         </textarea>
 
         <checkbox name="livetv" from="basecheckbox">
-            <position>90,340</position>
+            <position>90,390</position>
         </checkbox>
 
         <textarea name="livelabel" from="titlelabel">
-            <position>140,340</position>
+            <position>140,390</position>
             <value>Show LiveTV</value>
         </textarea>
 
         <checkbox name="watched" from="basecheckbox">
-            <position>90,390</position>
+            <position>90,440</position>
         </checkbox>
 
         <textarea name="watchedlabel" from="titlelabel">
-            <position>140,390</position>
+            <position>140,440</position>
             <value>Show Watched Programs</value>
         </textarea>
 
         <button name="save" from="basebutton">
-            <position>315,435</position>
+            <position>315,485</position>
             <value>Save</value>
         </button>
     </window>


### PR DESCRIPTION
A recording is considered "partially watched" if it has a bookmark and hasn't been marked watched. This is useful when you don't watch an entire recording in one sitting and want to pick it back up later. Having it in its own group makes it much easier to find.