### PR TITLE
Disable relative dates names like "Today" and "Yesterday"

### DIFF
--- a/mythtv/libs/libmythbase/mythdate.cpp
+++ b/mythtv/libs/libmythbase/mythdate.cpp
@@ -149,20 +149,6 @@ QString toString(const QDate &date, uint format)
                 stringformat.append(" yyyy");
         }
 
-        // Commenting out to disable relative date names like "Today" and
-        // "Yesterday".
-        //
-        // if (format & ~kDateShort)
-        // {
-        //     QDate now = current().toLocalTime().date();
-        //     if ((format & kSimplify) && (now == date))
-        //         result = QCoreApplication::translate("(Common)", "Today");
-        //     else if ((format & kSimplify) && (now.addDays(-1) == date))
-        //         result = QCoreApplication::translate("(Common)", "Yesterday");
-        //     else if ((format & kSimplify) && (now.addDays(1) == date))
-        //         result = QCoreApplication::translate("(Common)", "Tomorrow");
-        // }
-
         if (result.isEmpty())
             result = gCoreContext->GetQLocale().toString(date, stringformat);
     }

--- a/mythtv/libs/libmythbase/mythdate.cpp
+++ b/mythtv/libs/libmythbase/mythdate.cpp
@@ -149,16 +149,19 @@ QString toString(const QDate &date, uint format)
                 stringformat.append(" yyyy");
         }
 
-        if (format & ~kDateShort)
-        {
-            QDate now = current().toLocalTime().date();
-            if ((format & kSimplify) && (now == date))
-                result = QCoreApplication::translate("(Common)", "Today");
-            else if ((format & kSimplify) && (now.addDays(-1) == date))
-                result = QCoreApplication::translate("(Common)", "Yesterday");
-            else if ((format & kSimplify) && (now.addDays(1) == date))
-                result = QCoreApplication::translate("(Common)", "Tomorrow");
-        }
+        // Commenting out to disable relative date names like "Today" and
+        // "Yesterday".
+        //
+        // if (format & ~kDateShort)
+        // {
+        //     QDate now = current().toLocalTime().date();
+        //     if ((format & kSimplify) && (now == date))
+        //         result = QCoreApplication::translate("(Common)", "Today");
+        //     else if ((format & kSimplify) && (now.addDays(-1) == date))
+        //         result = QCoreApplication::translate("(Common)", "Yesterday");
+        //     else if ((format & kSimplify) && (now.addDays(1) == date))
+        //         result = QCoreApplication::translate("(Common)", "Tomorrow");
+        // }
 
         if (result.isEmpty())
             result = gCoreContext->GetQLocale().toString(date, stringformat);


### PR DESCRIPTION
The relative dates are disorienting to me. I'd much rather see the actual date.