### PR TITLE
Change buttonlist log message from INFO to DEBUG level

### DIFF
--- a/mythtv/libs/libmythui/mythuibuttonlist.cpp
+++ b/mythtv/libs/libmythui/mythuibuttonlist.cpp
@@ -2772,7 +2772,7 @@ void MythUIButtonList::customEvent(QEvent *event)
         {
             const int loginterval = (cur < 1000 ? 100 : 500);
             if (cur > 200 && cur % loginterval == 0)
-                LOG(VB_GUI, LOG_INFO,
+                LOG(VB_GUI, LOG_DEBUG,
                     QString("Build background buttonlist item %1").arg(cur));
             emit itemLoaded(GetItemAt(cur));
         }


### PR DESCRIPTION
Very minor. Avoids spamming the log with what seems like a debug message.