### PR TITLE
Don't include selected item in video tree breadcrumbs

### DIFF
--- a/mythtv/programs/mythfrontend/videodlg.cpp
+++ b/mythtv/programs/mythfrontend/videodlg.cpp
@@ -2405,7 +2405,14 @@ void VideoDialog::UpdateText(MythUIButtonListItem *item)
 
     if (m_d->m_currentNode)
     {
-        CheckedSet(m_crumbText, m_d->m_currentNode->getRouteByString().join(" > "));
+        if (m_d->m_currentNode == m_d->m_rootNode)
+        {
+            CheckedSet(m_crumbText, QObject::tr("Video Home"));
+        }
+        else
+        {
+            CheckedSet(m_crumbText, m_d->m_currentNode->getParent()->getRouteByString().join(" > "));
+        }
         CheckedSet(this, "foldername", m_d->m_currentNode->GetText());
     }
 


### PR DESCRIPTION
End the breadcrumbs at the parent item instead of the selected item. For example, if you're in a directory and the selected item is a file in that directory, then the last element in the breadcrumbs is the directory name, not the file name. Presumably, the selected item will be highlighted in some way, so you don't need it to appear in the breadcrumbs also.