### PR TITLE
Add support for <template> in the GuideGrid's date widgets

### DIFF
--- a/mythtv/programs/mythfrontend/guidegrid.cpp
+++ b/mythtv/programs/mythfrontend/guidegrid.cpp
@@ -525,8 +525,6 @@ GuideGrid::GuideGrid(MythScreenStack *parent,
            m_timeList(NULL),
            m_channelList(NULL),
            m_guideGrid(NULL),
-           m_dateText(NULL),
-           m_longdateText(NULL),
            m_jumpToText(NULL),
            m_changroupname(NULL),
            m_channelImage(NULL)
@@ -569,8 +567,6 @@ bool GuideGrid::Create()
     UIUtilE::Assign(this, m_timeList, "timelist", &err);
     UIUtilE::Assign(this, m_channelList, "channellist", &err);
     UIUtilE::Assign(this, m_guideGrid, "guidegrid", &err);
-    UIUtilW::Assign(this, m_dateText, "datetext");
-    UIUtilW::Assign(this, m_longdateText, "longdatetext");
     UIUtilW::Assign(this, m_changroupname, "channelgroup");
     UIUtilW::Assign(this, m_channelImage, "channelicon");
     UIUtilW::Assign(this, m_jumpToText, "jumptotext");
@@ -2058,11 +2054,11 @@ void GuideGrid::customEvent(QEvent *event)
 
 void GuideGrid::updateDateText(void)
 {
-    if (m_dateText)
-        m_dateText->SetText(MythDate::toString(m_currentStartTime, MythDate::kDateShort));
-    if (m_longdateText)
-        m_longdateText->SetText(MythDate::toString(m_currentStartTime,
-                                                 (MythDate::kDateFull | MythDate::kSimplify)));
+    InfoMap infomap;
+    infomap["datetext"] = MythDate::toString(m_currentStartTime, MythDate::kDateShort);
+    infomap["longdatetext"] = MythDate::toString(m_currentStartTime,
+                                                 (MythDate::kDateFull | MythDate::kSimplify));
+    SetTextFromMap(infomap);
 }
 
 void GuideGrid::updateProgramsUI(unsigned int firstRow, unsigned int numRows,

--- a/mythtv/programs/mythfrontend/guidegrid.h
+++ b/mythtv/programs/mythfrontend/guidegrid.h
@@ -286,8 +286,6 @@ private:
     MythUIButtonList *m_timeList;
     MythUIButtonList *m_channelList;
     MythUIGuideGrid  *m_guideGrid;
-    MythUIText       *m_dateText;
-    MythUIText       *m_longdateText;
     MythUIText       *m_jumpToText;
     MythUIText       *m_changroupname;
     MythUIImage      *m_channelImage;


### PR DESCRIPTION
The theme for the program guide (defined in `schedule-ui.xml`) supports date widgets named `datetext` and `longdatetext`. This adds support for the `<template>` tag to those widgets, meaning themers can add text around the date instead of being limited to displaying just the date.